### PR TITLE
Fix the go version

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21.0
+go 1.21
 
 use (
 	./central-service


### PR DESCRIPTION
*What?*
- The go version in the go.work file has an error and is not in the correct format.

*Why?*
- This correction ensures that the code will work even if a person has 1.21.1 or 1.21.2 Golang versions.