### PR TITLE
Fix RTC-Service Dockerfile

### DIFF
--- a/rtc-service/Dockerfile
+++ b/rtc-service/Dockerfile
@@ -3,10 +3,11 @@ FROM golang:1.21.0-alpine
 WORKDIR /app
 
 COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 
-COPY *.go ./
+COPY . .
 
-RUN go build -o /rtc-service
+RUN CGO_ENABLED=0 go build -o /rtc-service
 
 CMD ["/rtc-service"]


### PR DESCRIPTION
_What_
Fixes dependency issues with the RTC-Service Dockerfile

_Why_
Go would not find needed dependencies otherwise and the RTC-Service docker container would fail to build