### PR TITLE
Active round join user

### DIFF
--- a/bsg-frontend/apps/extension/hooks/useChatSocket.ts
+++ b/bsg-frontend/apps/extension/hooks/useChatSocket.ts
@@ -186,14 +186,14 @@ export const useChatSocket = () => {
                             const data = JSON.parse(message?.data || '{}');
                             setMessages(prev => [...prev, {
                                 userHandle: 'System',
-                                data: data.message || 'User joined the current Round',
+                                data: `${data.userName || data.userID} joined the round`,
                                 roomID: message.roomID,
                                 isSystem: true
-                            }]); 
+                            }]);
                             setLastGameEvent(
                                 {
                                 type: 'join-round',
-                                data: message.data,
+                                data,
                                 timestamp: Date.now()
                                 })
 

--- a/bsg-frontend/apps/extension/hooks/useChatSocket.ts
+++ b/bsg-frontend/apps/extension/hooks/useChatSocket.ts
@@ -126,18 +126,29 @@ export const useChatSocket = () => {
                         if (isNewMessage && fromOtherUser && !chatVisible) {
                             useRoomStore.getState().incrementUnread();
                         }
-                    } else if (responseType === 'system-announcement') {
+                    } else if (responseType === 'user-joined' || responseType === 'user-left') {
                         // Trigger participant refresh on join/leave.
                         useRoomStore.getState().setLastParticipantJoinTime(Date.now());
                         const messageData = message?.data || '';
                         // Our own join announcement confirms the socket is live — re-enable sounds.
-                        if (messageData.endsWith(' joined the room')) {
+                        if (responseType === 'user-joined') {
                             suppressChatSoundsRef.current = false;
                         }
-                        // e.g. "[name] joined the room", "[name] left the room", "Round has ended!"
+                        // A silent rejoin carries no text and should not render a blank line.
+                        if (messageData) {
+                            // e.g. "[name] joined the room", "[name] left the room"
+                            setMessages(prev => [...prev, {
+                                userHandle: 'System',
+                                data: messageData,
+                                roomID: message.roomID,
+                                isSystem: true
+                            }]);
+                        }
+                    } else if (responseType === 'system-announcement') {
+                        // e.g. "Round has ended!", "[name] solved [problem]"
                         setMessages(prev => [...prev, {
                             userHandle: 'System',
-                            data: messageData,
+                            data: message?.data || '',
                             roomID: message.roomID,
                             isSystem: true
                         }]);
@@ -161,6 +172,9 @@ export const useChatSocket = () => {
                             console.error('Failed to parse admin-change data', e);
                         }
                     } else if (responseType === 'round-start') {
+                        // No chat line here: rtc-service stores "The round has started"
+                        // as an announcement, which arrives via replay after the
+                        // navigation below reloads the panel.
                         try {
                             const parsedData = JSON.parse(message.data);
                             setLastGameEvent({
@@ -228,16 +242,19 @@ export const useChatSocket = () => {
     }, [userId]);
 
     const joinChatRoom = useCallback((roomID: string) => {
-        // Clear messages when joining a new room so we don't see chat history from previous rooms
-        setMessages([]);
-        setLastGameEvent(null);
-        suppressChatSoundsRef.current = true;  
+        suppressChatSoundsRef.current = true;
         useRoomStore.getState().clearUnread(); // checks uread
 
+        // Already in this room: no join-room is sent, so no history replay follows.
+        // Clearing here would wipe the chat with nothing to restore it.
         if (joinedRoomIDRef.current === roomID) {
             pendingRoomIDRef.current = roomID;
             return;
         }
+
+        // Clear messages when joining a new room so we don't see chat history from previous rooms
+        setMessages([]);
+        setLastGameEvent(null);
 
         pendingRoomIDRef.current = roomID;
 

--- a/bsg-frontend/apps/extension/hooks/useChatSocket.ts
+++ b/bsg-frontend/apps/extension/hooks/useChatSocket.ts
@@ -181,6 +181,22 @@ export const useChatSocket = () => {
                             data: message.data,
                             timestamp: Date.now()
                         });
+                    } else if (responseType === 'round-join') {
+
+                            const data = JSON.parse(message?.data || '{}');
+                            setMessages(prev => [...prev, {
+                                userHandle: 'System',
+                                data: data.message || 'User joined the current Round',
+                                roomID: message.roomID,
+                                isSystem: true
+                            }]); 
+                            setLastGameEvent(
+                                {
+                                type: 'join-round',
+                                data: message.data,
+                                timestamp: Date.now()
+                                })
+
                     } else if (responseType === 'next-problem') {
                         try {
                             const parsedData = JSON.parse(message.data);

--- a/bsg-frontend/apps/extension/hooks/useChatSocket.ts
+++ b/bsg-frontend/apps/extension/hooks/useChatSocket.ts
@@ -54,7 +54,7 @@ export const useChatSocket = () => {
     const [atLimit, setAtLimit] = useState<boolean>(false);
     const [emojiSearch, setEmojiSearch] = useState<string>('');
 
-    const userEmail = useUserStore(s => s.email);
+    const userId = useUserStore(s => s.userId);
     const username = useUserStore(s => s.username);
     const iconUrl = useUserStore(s => s.iconUrl);
     const roomId = useRoomStore(s => s.roomId);
@@ -62,7 +62,7 @@ export const useChatSocket = () => {
     const setLastGameEvent = useRoomStore(s => s.setLastGameEvent);
 
     useEffect(() => {
-        if (!userEmail) return;
+        if (!userId) return;
 
         const ws = new WebSocket(getRtcUrl());
         socketRef.current = ws;
@@ -73,15 +73,15 @@ export const useChatSocket = () => {
             //race-condition prevention joinRoom was happening before
             //the wb connection
             const targetRoomID = pendingRoomIDRef.current || roomId;
-            if(userEmail && targetRoomID){
+            if(userId && targetRoomID){
                 if (joinedRoomIDRef.current === targetRoomID) {
                     return;
                 }
                 const payload ={
-                    name:userEmail,
+                    name:userId,
                     "request-type": "join-room",
                     data: JSON.stringify({
-                        userHandle: userEmail,
+                        userHandle: userId,
                         userName: username,
                         roomID: targetRoomID
                     })
@@ -112,7 +112,7 @@ export const useChatSocket = () => {
 
                         // checks user handle to know if the message is sent by the user or received from others
                         if (!suppressChatSoundsRef.current) {
-                            if (message.userHandle === userEmail) {
+                            if (message.userHandle === userId) {
                                 playChatSound('message-sent.mp3');
                             } else {
                                 playChatSound('message-recieved.mp3');
@@ -121,7 +121,7 @@ export const useChatSocket = () => {
 
                         // for chat notification count - increment
                         const isNewMessage = !suppressChatSoundsRef.current;
-                        const fromOtherUser = message.userHandle !== userEmail;
+                        const fromOtherUser = message.userHandle !== userId;
                         const chatVisible = isChatVisible();
                         if (isNewMessage && fromOtherUser && !chatVisible) {
                             useRoomStore.getState().incrementUnread();
@@ -225,7 +225,7 @@ export const useChatSocket = () => {
         return () => {
             ws.close();
         };
-    }, [userEmail]);
+    }, [userId]);
 
     const joinChatRoom = useCallback((roomID: string) => {
         // Clear messages when joining a new room so we don't see chat history from previous rooms
@@ -241,12 +241,12 @@ export const useChatSocket = () => {
 
         pendingRoomIDRef.current = roomID;
 
-        if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN && userEmail) {
+        if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN && userId) {
             const payload = {
-                name: userEmail,
+                name: userId,
                 "request-type": "join-room",
                 data: JSON.stringify({
-                    userHandle: userEmail,
+                    userHandle: userId,
                     userName: username,
                     roomID: roomID
                 })
@@ -255,7 +255,7 @@ export const useChatSocket = () => {
             socketRef.current.send(JSON.stringify(payload));
             joinedRoomIDRef.current = roomID;
         }
-    }, [userEmail]);
+    }, [userId]);
 
     const handleSubmit = () => {
         const chat = chatRef.current;
@@ -265,12 +265,12 @@ export const useChatSocket = () => {
         const text = inputText.trim();
         if (!text) return;
 
-        if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN && userEmail) {
+        if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN && userId) {
             const payload = {
-                name: userEmail,
+                name: userId,
                 "request-type": "chat-message",
                 data: JSON.stringify({
-                    userHandle: userEmail,
+                    userHandle: userId,
                     userName: username,
                     userPhoto: iconUrl,
                     roomID: roomId,

--- a/bsg-frontend/apps/extension/hooks/useRoomEvents.ts
+++ b/bsg-frontend/apps/extension/hooks/useRoomEvents.ts
@@ -70,7 +70,7 @@ export function useRoomEvents() {
 
                 //we got here meaning re-render actually happened or someone left the tab so we should
                 //go to the problem page
-                if(LastGameEvent === 'round-start' || LastGameEvent === 'round-join'){
+                if(LastGameEvent === 'round-start' || LastGameEvent === 'join-round'){
                     const storedProblems: string[] = result.problems || [];
                     const storedEndTime: number | null = result.roundEndTime ?? null;
 
@@ -100,10 +100,9 @@ export function useRoomEvents() {
     useEffect(() => {
         if (!lastGameEvent || !roomId) return;
 
-        if (lastGameEvent.type === 'round-start') {
-            LastGameRef.current = 'round-start'
-            setRoomParticipants(roomId);
-            const data = lastGameEvent.data;
+        // Shared by round-start and join-round: both put a client into a running
+        // round, the only difference being whether it was there when it began.
+        const applyRoundData = (data: any) => {
             let problems: string[] = [];
             let endTime: number;
 
@@ -140,14 +139,14 @@ export function useRoomEvents() {
                 if (chrome.action) chrome.action.setBadgeText({ text: "" });
             }
 
-            if (problems.length > 0) { 
+            if (problems.length > 0) {
                 if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
                     chrome.storage.local.set({ problems: problems})
                 }
                 const targetSlug = problems[0]
 
                 const NavigateProblem = async () => {
-                
+
                 if (!chrome.tabs) return;
                     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
                 if (!tab?.id || !tab.url) return;
@@ -157,17 +156,36 @@ export function useRoomEvents() {
                     chrome.tabs.update(tab.id, { url: problemUrl(targetSlug) });
                 }
                 return;
-                
+
                 }
 
                 NavigateProblem();
 
 
             }
+        };
+
+        if (lastGameEvent.type === 'round-start') {
+            LastGameRef.current = 'round-start'
+            setRoomParticipants(roomId);
+            applyRoundData(lastGameEvent.data);
             //problem array kept getting erased due to zustand stored it here and the lastGameEvent as well
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
                 chrome.storage.local.set({ lastGameEvent: lastGameEvent.type})
-            } 
+            }
+        } else if (lastGameEvent.type === 'join-round') {
+            LastGameRef.current = 'join-round'
+            setRoomParticipants(roomId);
+
+            // join-round is broadcast to the whole room, so only the user who
+            // actually joined should be set up and navigated.
+            const data = lastGameEvent.data;
+            if (data?.userID === userId && data?.roundStatus === 'in-progress') {
+                applyRoundData(data);
+                if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+                    chrome.storage.local.set({ lastGameEvent: lastGameEvent.type})
+                }
+            }
         } else if (lastGameEvent.type === 'next-problem') {
             LastGameRef.current = 'next-problem'
             let eventData = lastGameEvent.data;

--- a/bsg-frontend/apps/extension/hooks/useRoomEvents.ts
+++ b/bsg-frontend/apps/extension/hooks/useRoomEvents.ts
@@ -70,7 +70,7 @@ export function useRoomEvents() {
 
                 //we got here meaning re-render actually happened or someone left the tab so we should
                 //go to the problem page
-                if(LastGameEvent === 'round-start'){
+                if(LastGameEvent === 'round-start' || LastGameEvent === 'round-join'){
                     const storedProblems: string[] = result.problems || [];
                     const storedEndTime: number | null = result.roundEndTime ?? null;
 

--- a/bsg-frontend/packages/models/GameEvent.ts
+++ b/bsg-frontend/packages/models/GameEvent.ts
@@ -1,5 +1,5 @@
 export type GameEvent = {
-    type: 'round-start' | 'next-problem' | 'round-end',
+    type: 'round-start' | 'next-problem' | 'round-end' | 'join-round',
     data: any,
     timestamp: number
 }

--- a/central-service/services/room.go
+++ b/central-service/services/room.go
@@ -221,14 +221,6 @@ func (service *RoomService) JoinRoom(roomID string, userID string) (*models.Room
 	if err = service.addJoinMember(roomID, userID); err != nil {
 		return nil, err
 	}
-	if len(room.Rounds) > 0 {
-		round := room.Rounds[len(room.Rounds)-1]
-		if round.Status == constants.ROUND_STARTED {
-			if err := service.roundService.CreateRoundParticipant(userID, round.ID); err != nil {
-				return nil, err
-			}
-		}
-	}
 	// RTCClient is nil in test cases
 	if service.rtcClient != nil {
 		joinRoom := requests.JoinRoomRequest{
@@ -244,6 +236,30 @@ func (service *RoomService) JoinRoom(roomID string, userID string) (*models.Room
 			}
 		}
 	}
+	if len(room.Rounds) > 0 {
+		round := room.Rounds[len(room.Rounds)-1]
+		if round.Status == constants.ROUND_STARTED {
+			if err := service.roundService.CreateRoundParticipant(userID, round.ID); err != nil {
+				return nil, err
+			}
+			if service.rtcClient != nil {
+				joinRound := requests.JoinRoundRequest{
+					RoomID: roomID,
+					UserID: userID,
+				}
+				if _, err = service.rtcClient.SendMessage("join-round", joinRound); err != nil {
+					log.Printf("Error sending  message: %v", err)
+					return nil, BSGError{
+						StatusCode: 500,
+						Message:    "Internal Server Error",
+					}
+				}
+
+			}
+
+		}
+	}
+
 	return room, nil
 }
 

--- a/central-service/services/room.go
+++ b/central-service/services/room.go
@@ -243,9 +243,15 @@ func (service *RoomService) JoinRoom(roomID string, userID string) (*models.Room
 				return nil, err
 			}
 			if service.rtcClient != nil {
+				var userName string
+				var user models.User
+				if err := service.db.Where("auth_id = ?", userID).First(&user).Error; err == nil {
+					userName = user.Handle
+				}
 				joinRound := requests.JoinRoundRequest{
-					RoomID: roomID,
-					UserID: userID,
+					RoomID:   roomID,
+					UserID:   userID,
+					UserName: userName,
 				}
 				if _, err = service.rtcClient.SendMessage("join-round", joinRound); err != nil {
 					log.Printf("Error sending  message: %v", err)

--- a/central-service/services/room.go
+++ b/central-service/services/room.go
@@ -221,12 +221,15 @@ func (service *RoomService) JoinRoom(roomID string, userID string) (*models.Room
 	if err = service.addJoinMember(roomID, userID); err != nil {
 		return nil, err
 	}
+	displayName := service.userDisplayName(userID)
 	// RTCClient is nil in test cases
 	if service.rtcClient != nil {
+		// Announced here rather than suppressed so the room join is broadcast
+		// before the round join below, keeping the two in chronological order.
 		joinRoom := requests.JoinRoomRequest{
-			UserHandle:           userID,
-			RoomID:               roomID,
-			SuppressAnnouncement: true,
+			UserHandle: userID,
+			RoomID:     roomID,
+			UserName:   displayName,
 		}
 		if _, err = service.rtcClient.SendMessage("join-room", joinRoom); err != nil {
 			log.Printf("Error sending join-room message: %v", err)
@@ -243,15 +246,10 @@ func (service *RoomService) JoinRoom(roomID string, userID string) (*models.Room
 				return nil, err
 			}
 			if service.rtcClient != nil {
-				var userName string
-				var user models.User
-				if err := service.db.Where("auth_id = ?", userID).First(&user).Error; err == nil {
-					userName = user.Handle
-				}
 				joinRound := requests.JoinRoundRequest{
 					RoomID:   roomID,
 					UserID:   userID,
-					UserName: userName,
+					UserName: displayName,
 				}
 				if _, err = service.rtcClient.SendMessage("join-round", joinRound); err != nil {
 					log.Printf("Error sending  message: %v", err)
@@ -549,6 +547,23 @@ func (service *RoomService) StartRoundByRoomID(roomID string, userID string) (*t
 		log.Printf("Error initiating round start: %v\n", err)
 		return nil, nil, err
 	}
+
+	// Everyone in the room joins the round the moment it starts. Users who arrive
+	// later get their join-round from JoinRoom instead. Failures are logged rather
+	// than returned: a missing chat line should not fail the round start.
+	if service.rtcClient != nil {
+		for _, participantID := range activeUsers {
+			joinRound := requests.JoinRoundRequest{
+				RoomID:   roomID,
+				UserID:   participantID,
+				UserName: service.userDisplayName(participantID),
+			}
+			if _, err := service.rtcClient.SendMessage("join-round", joinRound); err != nil {
+				log.Printf("Error sending join-round message: %v", err)
+			}
+		}
+	}
+
 	return roundStartTime, problems, nil
 }
 

--- a/central-service/services/rtc-client.go
+++ b/central-service/services/rtc-client.go
@@ -28,9 +28,9 @@ type RTCClient struct {
 func expectedResponseType(requestType string) response.ResponseType {
 	switch requestType {
 	case "join-room":
-		return response.SYSTEM_ANNOUNCEMENT
+		return response.USER_JOINED
 	case "leave-room":
-		return response.SYSTEM_ANNOUNCEMENT
+		return response.USER_LEFT
 	case "chat-message":
 		return response.CHAT_MESSAGE
 	case "round-start":

--- a/central-service/services/rtc-client.go
+++ b/central-service/services/rtc-client.go
@@ -43,6 +43,8 @@ func expectedResponseType(requestType string) response.ResponseType {
 		return response.ROOM_EXPIRED
 	case "admin-change":
 		return response.ADMIN_CHANGE
+	case "join-round":
+		return response.ROUND_JOIN
 	default:
 		return ""
 	}

--- a/rtc-service/chatmanager/room.go
+++ b/rtc-service/chatmanager/room.go
@@ -70,6 +70,17 @@ func (r *Room) GetUser(userHandle string) *User {
 	return nil
 }
 
+// RemoveAllUsers clears the room's user list. Used when a room is torn down,
+// since RemoveRoom refuses to delete a room that still has users.
+func (r *Room) RemoveAllUsers() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Users = make(UserList)
+
+	logging.Info("All users removed from room: ", r.RoomID)
+}
+
 func (r *Room) IsEmpty() bool {
 	r.RLock()
 	defer r.RUnlock()

--- a/rtc-service/chatmanager/room.go
+++ b/rtc-service/chatmanager/room.go
@@ -21,6 +21,9 @@ type Room struct {
 	// List of all users in the room.
 	Users UserList
 
+	// State of the room's round. Nil until a round is started.
+	Round *Round
+
 	// History of messages in the room for persistence.
 	Messages []response.Response
 

--- a/rtc-service/chatmanager/round.go
+++ b/rtc-service/chatmanager/round.go
@@ -49,16 +49,27 @@ func (r *Room) StartRound(startTime int64, duration int, problems []string) {
 	logging.Info("Round started in room: ", r.RoomID)
 }
 
-// JoinRound registers a user as a participant and returns the round's status.
+// RoundInfo describes a round to callers outside this package. Problems is a
+// copy, so it stays safe to read once the Room's lock has been released.
+type RoundInfo struct {
+	Status    RoundStatus
+	StartTime int64
+	Duration  int
+	Problems  []string
+}
+
+// JoinRound registers a user as a participant and returns the round's shape, so
+// a user joining midway can be set up with the same problems and timing as
+// everyone who was there when it started.
 //
 // Joining is idempotent, so a reconnect or a second tab does not disturb a
 // participant who is already registered.
-func (r *Room) JoinRound(userID string) RoundStatus {
+func (r *Room) JoinRound(userID string) RoundInfo {
 	r.Lock()
 	defer r.Unlock()
 
 	if r.Round == nil {
-		return RoundNotStarted
+		return RoundInfo{Status: RoundNotStarted}
 	}
 
 	if !r.Round.Participants[userID] {
@@ -66,7 +77,15 @@ func (r *Room) JoinRound(userID string) RoundStatus {
 		logging.Info("User joined round: ", userID, " in room: ", r.RoomID)
 	}
 
-	return r.Round.Status
+	problems := make([]string, len(r.Round.Problems))
+	copy(problems, r.Round.Problems)
+
+	return RoundInfo{
+		Status:    r.Round.Status,
+		StartTime: r.Round.StartTime,
+		Duration:  r.Round.Duration,
+		Problems:  problems,
+	}
 }
 
 // EndRound marks the round finished. The participant list is kept so it can

--- a/rtc-service/chatmanager/round.go
+++ b/rtc-service/chatmanager/round.go
@@ -1,0 +1,84 @@
+package chatmanager
+
+import (
+	"github.com/acmutd/bsg/rtc-service/logging"
+)
+
+// RoundStatus tells the round status
+type RoundStatus string
+
+const (
+	// No round has been started in this room yet.
+	RoundNotStarted RoundStatus = "not-started"
+
+	// A round is currently running.
+	RoundInProgress RoundStatus = "in-progress"
+
+	// The round has finished.
+	RoundEnded RoundStatus = "ended"
+)
+
+// Round holds the state of a single room's round.
+type Round struct {
+	Status    RoundStatus
+	StartTime int64
+	Duration  int
+	Problems  []string
+
+	// Set of user IDs taking part in the round.
+	Participants map[string]bool
+}
+
+// StartRound replaces any existing round with a fresh one that is in progress.
+func (r *Room) StartRound(startTime int64, duration int, problems []string) {
+	r.Lock()
+	defer r.Unlock()
+
+	// Copy the caller's slice so later changes on their side cannot reach in.
+	problemsCopy := make([]string, len(problems))
+	copy(problemsCopy, problems)
+
+	r.Round = &Round{
+		Status:       RoundInProgress,
+		StartTime:    startTime,
+		Duration:     duration,
+		Problems:     problemsCopy,
+		Participants: make(map[string]bool),
+	}
+
+	logging.Info("Round started in room: ", r.RoomID)
+}
+
+// JoinRound registers a user as a participant and returns the round's status.
+//
+// Joining is idempotent, so a reconnect or a second tab does not disturb a
+// participant who is already registered.
+func (r *Room) JoinRound(userID string) RoundStatus {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.Round == nil {
+		return RoundNotStarted
+	}
+
+	if !r.Round.Participants[userID] {
+		r.Round.Participants[userID] = true
+		logging.Info("User joined round: ", userID, " in room: ", r.RoomID)
+	}
+
+	return r.Round.Status
+}
+
+// EndRound marks the round finished. The participant list is kept so it can
+// still be read after the round is over.
+func (r *Room) EndRound() {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.Round == nil {
+		return
+	}
+
+	r.Round.Status = RoundEnded
+	logging.Info("Round ended in room: ", r.RoomID)
+}

--- a/rtc-service/requests/join-room-request.go
+++ b/rtc-service/requests/join-room-request.go
@@ -40,7 +40,7 @@ func (r *JoinRoomRequest) validate() error {
 
 // Returns the response type for the request.
 func (r *JoinRoomRequest) responseType() response.ResponseType {
-	return response.SYSTEM_ANNOUNCEMENT
+	return response.USER_JOINED
 }
 
 // Handles the request and returns a response
@@ -72,11 +72,20 @@ func (r *JoinRoomRequest) Handle(m *Message) (response.ResponseType, string, str
 		chatmanager.RTCChatManager.CreateRoom(room)
 	}
 
+	// A user already in the room is reconnecting (a reload, or a second tab).
+	// Their socket still needs registering and a history replay, but announcing
+	// again would append a duplicate "joined the room" to every client.
+	rejoin := room.GetUser(r.UserHandle) != nil
+
 	user := &chatmanager.User{
 		Handle: r.UserHandle,
 		Room:   room,
 	}
 	room.AddUser(user)
+
+	if rejoin {
+		return r.responseType(), "", r.RoomID, nil
+	}
 
 	if r.SuppressAnnouncement {
 		// Silent join: the user is registered but no announcement is broadcast.

--- a/rtc-service/requests/join-round-request.go
+++ b/rtc-service/requests/join-round-request.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/acmutd/bsg/rtc-service/chatmanager"
 	"github.com/acmutd/bsg/rtc-service/response"
@@ -40,6 +41,14 @@ type joinRoundBroadcast struct {
 	UserID      string `json:"userID"`
 	UserName    string `json:"userName"`
 	RoundStatus string `json:"roundStatus"`
+
+	// Shape of the round the user joined, so a client joining midway can set
+	// itself up the same way round-start sets up everyone already present.
+	// Mirrors roundStartBroadcast so the frontend can parse both identically.
+	StartTime int64    `json:"startTime"`
+	ServerNow int64    `json:"serverNow"`
+	Duration  int      `json:"duration"`
+	Problems  []string `json:"problems"`
 }
 
 func (j *JoinRoundRequest) Handle(m *Message) (response.ResponseType, string, string, error) {
@@ -55,9 +64,9 @@ func (j *JoinRoundRequest) Handle(m *Message) (response.ResponseType, string, st
 
 	// A missing room means no round exists to join, which JoinRound would also
 	// report, so the status stays "not-started" rather than erroring.
-	status := chatmanager.RoundNotStarted
+	info := chatmanager.RoundInfo{Status: chatmanager.RoundNotStarted}
 	if room := chatmanager.RTCChatManager.GetRoom(j.RoomID); room != nil {
-		status = room.JoinRound(j.UserID)
+		info = room.JoinRound(j.UserID)
 	}
 
 	name := j.UserName
@@ -68,7 +77,11 @@ func (j *JoinRoundRequest) Handle(m *Message) (response.ResponseType, string, st
 	broadcast := joinRoundBroadcast{
 		UserID:      j.UserID,
 		UserName:    name,
-		RoundStatus: string(status),
+		RoundStatus: string(info.Status),
+		StartTime:   info.StartTime,
+		ServerNow:   time.Now().Unix(),
+		Duration:    info.Duration,
+		Problems:    info.Problems,
 	}
 	broadcastJSON, err := json.Marshal(broadcast)
 	if err != nil {

--- a/rtc-service/requests/join-round-request.go
+++ b/rtc-service/requests/join-round-request.go
@@ -3,13 +3,15 @@ package requests
 import (
 	"encoding/json"
 
+	"github.com/acmutd/bsg/rtc-service/chatmanager"
 	"github.com/acmutd/bsg/rtc-service/response"
 	"github.com/go-playground/validator/v10"
 )
 
 type JoinRoundRequest struct {
-	RoomID string `json:"roomID" validate:"required"`
-	UserID string `json:"userID" validate:"required"`
+	RoomID   string `json:"roomID" validate:"required"`
+	UserID   string `json:"userID" validate:"required"`
+	UserName string `json:"userName"`
 }
 
 func init() {
@@ -32,9 +34,11 @@ func (j *JoinRoundRequest) responseType() response.ResponseType {
 	return response.ROUND_JOIN
 }
 
-type JoinRoundBroadcast struct {
-	RoomID      string `json:"roomId"`
-	UserID      string `json:"userId"`
+// joinRoundBroadcast is the payload sent to every user in the room when a user
+// joins the current round.
+type joinRoundBroadcast struct {
+	UserID      string `json:"userID"`
+	UserName    string `json:"userName"`
 	RoundStatus string `json:"roundStatus"`
 }
 
@@ -49,15 +53,27 @@ func (j *JoinRoundRequest) Handle(m *Message) (response.ResponseType, string, st
 		return j.responseType(), "", j.RoomID, err
 	}
 
-	broadcast := JoinRoundBroadcast{
-		RoomID:      j.RoomID,
+	// A missing room means no round exists to join, which JoinRound would also
+	// report, so the status stays "not-started" rather than erroring.
+	status := chatmanager.RoundNotStarted
+	if room := chatmanager.RTCChatManager.GetRoom(j.RoomID); room != nil {
+		status = room.JoinRound(j.UserID)
+	}
+
+	name := j.UserName
+	if name == "" {
+		name = j.UserID
+	}
+
+	broadcast := joinRoundBroadcast{
 		UserID:      j.UserID,
-		RoundStatus: "Round is live",
+		UserName:    name,
+		RoundStatus: string(status),
 	}
 	broadcastJSON, err := json.Marshal(broadcast)
 	if err != nil {
 		return j.responseType(), "", j.RoomID, err
 	}
 
-	return j.responseType(), string(broadcastJSON), "", nil
+	return j.responseType(), string(broadcastJSON), j.RoomID, nil
 }

--- a/rtc-service/requests/join-round-request.go
+++ b/rtc-service/requests/join-round-request.go
@@ -1,0 +1,63 @@
+package requests
+
+import (
+	"encoding/json"
+
+	"github.com/acmutd/bsg/rtc-service/response"
+	"github.com/go-playground/validator/v10"
+)
+
+type JoinRoundRequest struct {
+	RoomID string `json:"roomID" validate:"required"`
+	UserID string `json:"userID" validate:"required"`
+}
+
+func init() {
+	register("join-round", &JoinRoundRequest{})
+}
+
+// create a new struct obj
+func (j *JoinRoundRequest) New() Request {
+	return &JoinRoundRequest{}
+}
+
+// validate the struct
+func (j *JoinRoundRequest) validate() error {
+	validate := validator.New()
+	return validate.Struct(j)
+}
+
+// Returns the response type for the request.
+func (j *JoinRoundRequest) responseType() response.ResponseType {
+	return response.ROUND_JOIN
+}
+
+type JoinRoundBroadcast struct {
+	RoomID      string `json:"roomId"`
+	UserID      string `json:"userId"`
+	RoundStatus string `json:"roundStatus"`
+}
+
+func (j *JoinRoundRequest) Handle(m *Message) (response.ResponseType, string, string, error) {
+	err := json.Unmarshal([]byte(m.Data), j)
+	if err != nil {
+		return j.responseType(), "", "", err
+	}
+	// Validate the request.
+	err = j.validate()
+	if err != nil {
+		return j.responseType(), "", j.RoomID, err
+	}
+
+	broadcast := JoinRoundBroadcast{
+		RoomID:      j.RoomID,
+		UserID:      j.UserID,
+		RoundStatus: "Round is live",
+	}
+	broadcastJSON, err := json.Marshal(broadcast)
+	if err != nil {
+		return j.responseType(), "", j.RoomID, err
+	}
+
+	return j.responseType(), string(broadcastJSON), "", nil
+}

--- a/rtc-service/requests/leave-room-request.go
+++ b/rtc-service/requests/leave-room-request.go
@@ -38,7 +38,7 @@ func (r *LeaveRoomRequest) validate() error {
 
 // Returns the response type for the request.
 func (r *LeaveRoomRequest) responseType() response.ResponseType {
-	return response.SYSTEM_ANNOUNCEMENT
+	return response.USER_LEFT
 }
 
 // Handles the request and returns a response.

--- a/rtc-service/requests/room-expired-request.go
+++ b/rtc-service/requests/room-expired-request.go
@@ -39,5 +39,8 @@ func (r *RoomExpiredRequest) Handle(m *Message) (response.ResponseType, string, 
 	if err != nil {
 		return r.responseType(), "", r.RoomID, err
 	}
+	// The room itself is torn down in ReadMessages, after this notice has been
+	// broadcast. Removing it here would empty the room before delivery and the
+	// people in it would never hear that it expired.
 	return r.responseType(), "Room has expired and been deleted.", r.RoomID, nil
 }

--- a/rtc-service/requests/round-end-request.go
+++ b/rtc-service/requests/round-end-request.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"encoding/json"
 
+	"github.com/acmutd/bsg/rtc-service/chatmanager"
 	"github.com/acmutd/bsg/rtc-service/response"
 	"github.com/go-playground/validator/v10"
 )
@@ -51,5 +52,10 @@ func (r *RoundEndRequest) Handle(m *Message) (response.ResponseType, string, str
 	if err != nil {
 		return r.responseType(), "", r.RoomID, err
 	}
+
+	if room := chatmanager.RTCChatManager.GetRoom(r.RoomID); room != nil {
+		room.EndRound()
+	}
+
 	return r.responseType(), "Round has ended!", r.RoomID, nil
 }

--- a/rtc-service/requests/round-start-request.go
+++ b/rtc-service/requests/round-start-request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/acmutd/bsg/rtc-service/chatmanager"
 	"github.com/acmutd/bsg/rtc-service/response"
 	"github.com/go-playground/validator/v10"
 )
@@ -60,6 +61,10 @@ func (r *RoundStartRequest) Handle(m *Message) (response.ResponseType, string, s
 	err = r.validate()
 	if err != nil {
 		return r.responseType(), "", r.RoomID, err
+	}
+
+	if room := chatmanager.RTCChatManager.GetRoom(r.RoomID); room != nil {
+		room.StartRound(r.StartTime, r.Duration, r.ProblemList)
 	}
 
 	broadcast := roundStartBroadcast{

--- a/rtc-service/requests/round-start-request.go
+++ b/rtc-service/requests/round-start-request.go
@@ -65,6 +65,12 @@ func (r *RoundStartRequest) Handle(m *Message) (response.ResponseType, string, s
 
 	if room := chatmanager.RTCChatManager.GetRoom(r.RoomID); room != nil {
 		room.StartRound(r.StartTime, r.Duration, r.ProblemList)
+
+		// The round-start response itself is a control event: clients navigate to
+		// the problem page when they receive one, so it is never replayed. The
+		// chat line is stored separately as a plain announcement, which replays
+		// safely and survives the navigation reload that follows.
+		room.AddMessage(*response.NewOkResponse(response.SYSTEM_ANNOUNCEMENT, "The round has started", r.RoomID))
 	}
 
 	broadcast := roundStartBroadcast{

--- a/rtc-service/response/response-types.go
+++ b/rtc-service/response/response-types.go
@@ -12,6 +12,12 @@ var (
 	// Response type that doesn't require any special handling.
 	GENERAL ResponseType = "general"
 
+	// A user joined a room. Transient: not kept in room history.
+	USER_JOINED ResponseType = "user-joined"
+
+	// A user left a room. Transient: not kept in room history.
+	USER_LEFT ResponseType = "user-left"
+
 	// round start broadcast
 	ROUND_START ResponseType = "round-start"
 

--- a/rtc-service/response/response-types.go
+++ b/rtc-service/response/response-types.go
@@ -15,6 +15,9 @@ var (
 	// round start broadcast
 	ROUND_START ResponseType = "round-start"
 
+	// round join broadcast
+	ROUND_JOIN ResponseType = "round-join"
+
 	// next problem broadcast
 	NEXT_PROBLEM ResponseType = "next-problem"
 

--- a/rtc-service/response/response.go
+++ b/rtc-service/response/response.go
@@ -43,7 +43,7 @@ func NewErrorResponse(responseType ResponseType, message string, roomID string) 
 		Data: message,
 	}
 
-	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE {
+	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN {
 		respMessage.RoomID = roomID
 	}
 	return &Response{
@@ -59,7 +59,7 @@ func NewOkResponse(responseType ResponseType, message string, roomID string) *Re
 	userName := ""
 	userPhoto := ""
 	data := message
-	
+
 	if responseType == CHAT_MESSAGE && message != "" {
 		// Try to unmarshal JSON first
 		var chatData map[string]string
@@ -86,7 +86,7 @@ func NewOkResponse(responseType ResponseType, message string, roomID string) *Re
 		UserPhoto:  userPhoto,
 	}
 
-	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE {
+	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN {
 		respMessage.RoomID = roomID
 	}
 	return &Response{

--- a/rtc-service/response/response.go
+++ b/rtc-service/response/response.go
@@ -43,7 +43,7 @@ func NewErrorResponse(responseType ResponseType, message string, roomID string) 
 		Data: message,
 	}
 
-	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN {
+	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN || responseType == ROUND_START || responseType == USER_JOINED || responseType == USER_LEFT {
 		respMessage.RoomID = roomID
 	}
 	return &Response{
@@ -86,7 +86,7 @@ func NewOkResponse(responseType ResponseType, message string, roomID string) *Re
 		UserPhoto:  userPhoto,
 	}
 
-	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN {
+	if responseType == SYSTEM_ANNOUNCEMENT || responseType == CHAT_MESSAGE || responseType == ADMIN_CHANGE || responseType == ROUND_JOIN || responseType == ROUND_START || responseType == USER_JOINED || responseType == USER_LEFT {
 		respMessage.RoomID = roomID
 	}
 	return &Response{

--- a/rtc-service/servicesmanager/service.go
+++ b/rtc-service/servicesmanager/service.go
@@ -50,18 +50,12 @@ func NewClient(name string, conn *websocket.Conn, manager *ServiceManager) *Serv
 // Read the incoming messages from the service.
 func (s *Service) ReadMessages() {
 	defer func() {
-		// If this was the last connection for the user's handle, remove their
-		// room entry so reconnects don't collide and rooms can be cleaned up.
-		// Other connections sharing the handle (e.g. a second tab) keep the entry.
-		if s.JoinedRoom != "" && s.ServiceManager.FindOtherService(s.Name, s) == nil {
-			room := chatmanager.RTCChatManager.GetRoom(s.JoinedRoom)
-			if room != nil {
-				room.RemoveUser(&chatmanager.User{Handle: s.Name})
-				if room.IsEmpty() {
-					chatmanager.RTCChatManager.RemoveRoom(room)
-				}
-			}
-		}
+		// Neither the user nor the room is removed here. A dropped socket means
+		// this connection is gone, not that the user left or the round is over,
+		// and the panel reconnects routinely (navigating to a problem reloads it).
+		// Removing the user made the reconnect look like a fresh join, which
+		// announced them twice; removing the room discarded its history and round
+		// state outright. Users leave via leave-room, rooms via room-expired.
 		s.ServiceManager.RemoveService(s)
 	}()
 
@@ -107,26 +101,39 @@ func (s *Service) ReadMessages() {
 					// Silent announcements (e.g. central-service registering a user in
 					// the room) carry an empty message and are neither broadcast nor
 					// stored in history. The user is already registered by Handle().
-					silentAnnouncement := respType == response.SYSTEM_ANNOUNCEMENT && resp == ""
+					silentAnnouncement := (respType == response.SYSTEM_ANNOUNCEMENT || respType == response.USER_JOINED) && resp == ""
+
+					// 1. Replay history to a joining user. This runs even when their own
+					// join is silent (a reconnect, or central-service registering them),
+					// because whether their arrival is announced has nothing to do with
+					// whether they need the messages they missed.
+					if messageStruct.Type == "join-room" {
+						if room := chatmanager.RTCChatManager.GetRoom(roomID); room != nil {
+							room.RLock()
+							for _, prevMsg := range room.Messages {
+								// ROUND_START and NEXT_PROBLEM are control events: the frontend
+								// navigates the tab when it sees one, so replaying them would
+								// re-trigger navigation on every reconnect.
+								if prevMsg.RespType == response.CHAT_MESSAGE || prevMsg.RespType == response.SYSTEM_ANNOUNCEMENT || prevMsg.RespType == response.ROUND_JOIN || prevMsg.RespType == response.USER_JOINED || prevMsg.RespType == response.USER_LEFT {
+									s.Egress <- prevMsg
+								}
+							}
+							room.RUnlock()
+						}
+					}
 
 					// Broadcast and Persistence Logic
-					if !silentAnnouncement && (respType == response.CHAT_MESSAGE || respType == response.SYSTEM_ANNOUNCEMENT || respType == response.ROUND_START || respType == response.NEXT_PROBLEM || respType == response.ROOM_EXPIRED || respType == response.ADMIN_CHANGE || respType == response.ROUND_JOIN) {
+					if !silentAnnouncement && (respType == response.CHAT_MESSAGE || respType == response.SYSTEM_ANNOUNCEMENT || respType == response.ROUND_START || respType == response.NEXT_PROBLEM || respType == response.ROOM_EXPIRED || respType == response.ADMIN_CHANGE || respType == response.ROUND_JOIN || respType == response.USER_JOINED || respType == response.USER_LEFT) {
 						room := chatmanager.RTCChatManager.GetRoom(roomID)
 						if room != nil {
-							// 1. If this is a join-room request, replay history to the joining user.
-							if messageStruct.Type == "join-room" {
-								room.RLock()
-								for _, prevMsg := range room.Messages {
-									// Only replay non-transient events on reconnect.
-									if prevMsg.RespType == response.CHAT_MESSAGE || prevMsg.RespType == response.SYSTEM_ANNOUNCEMENT || prevMsg.RespType == response.ROUND_JOIN {
-										s.Egress <- prevMsg
-									}
-								}
-								room.RUnlock()
+							// 2. Save the current message to history. Rejoins are silent, so
+							// each user contributes at most one join entry rather than one
+							// per reconnect. Control events are skipped: they are never
+							// replayed, so storing them would only consume history slots
+							// and evict real messages.
+							if respType != response.ROUND_START && respType != response.NEXT_PROBLEM {
+								room.AddMessage(respObj)
 							}
-
-							// 2. Save the current message to history.
-							room.AddMessage(respObj)
 
 							// 3. Send to all users in the room.
 							senderReceived := false
@@ -149,6 +156,18 @@ func (s *Service) ReadMessages() {
 						}
 					} else {
 						s.Egress <- respObj
+					}
+
+					// central-service owns the room lifecycle, so room-expired is the
+					// signal that a room is genuinely over. Tearing it down here rather
+					// than on socket disconnect keeps history and round state alive
+					// across the reconnects the panel does routinely. Done after the
+					// broadcast above so everyone still in the room hears about it.
+					if respType == response.ROOM_EXPIRED {
+						if room := chatmanager.RTCChatManager.GetRoom(roomID); room != nil {
+							room.RemoveAllUsers()
+							chatmanager.RTCChatManager.RemoveRoom(room)
+						}
 					}
 
 					frontEnd := s.ServiceManager.FindService(FRONT_END_SERVICE)

--- a/rtc-service/servicesmanager/service.go
+++ b/rtc-service/servicesmanager/service.go
@@ -110,7 +110,7 @@ func (s *Service) ReadMessages() {
 					silentAnnouncement := respType == response.SYSTEM_ANNOUNCEMENT && resp == ""
 
 					// Broadcast and Persistence Logic
-					if !silentAnnouncement && (respType == response.CHAT_MESSAGE || respType == response.SYSTEM_ANNOUNCEMENT || respType == response.ROUND_START || respType == response.NEXT_PROBLEM || respType == response.ROOM_EXPIRED || respType == response.ADMIN_CHANGE) {
+					if !silentAnnouncement && (respType == response.CHAT_MESSAGE || respType == response.SYSTEM_ANNOUNCEMENT || respType == response.ROUND_START || respType == response.NEXT_PROBLEM || respType == response.ROOM_EXPIRED || respType == response.ADMIN_CHANGE || respType == response.ROUND_JOIN) {
 						room := chatmanager.RTCChatManager.GetRoom(roomID)
 						if room != nil {
 							// 1. If this is a join-room request, replay history to the joining user.

--- a/rtc-service/servicesmanager/service.go
+++ b/rtc-service/servicesmanager/service.go
@@ -118,7 +118,7 @@ func (s *Service) ReadMessages() {
 								room.RLock()
 								for _, prevMsg := range room.Messages {
 									// Only replay non-transient events on reconnect.
-									if prevMsg.RespType == response.CHAT_MESSAGE || prevMsg.RespType == response.SYSTEM_ANNOUNCEMENT {
+									if prevMsg.RespType == response.CHAT_MESSAGE || prevMsg.RespType == response.SYSTEM_ANNOUNCEMENT || prevMsg.RespType == response.ROUND_JOIN {
 										s.Egress <- prevMsg
 									}
 								}


### PR DESCRIPTION
## Issue
If a user joined a room while a round was already in progress, they were never placed in that round — no problems, no timer, no redirect.

## The Fix
Created `chatmanager/round.go` to track round state per room. `Round` hangs off `Room` and is guarded by the Room's existing `RWMutex` rather than carrying its own lock, so the two can't be acquired out of order. `round-start`, `join-round`, and `round-end` now drive `StartRound` / `JoinRound` / `EndRound`.

The `join-round` broadcast carries the round's shape (status, startTime, duration, problems), so a user joining midway gets set up exactly like everyone who was there at the start — problem list stored, end time set, redirected to the problem screen.

## Refactors
**Announcements.** Join/leave got their own response types (`user-joined` / `user-left`) instead of sharing `system-announcement` with things worth keeping. Rejoins are now silent, so reconnects stop appending duplicate "X joined the room" to history. Control events (`round-start`, `next-problem`) are broadcast live but never persisted or replayed — replaying them re-fired the tab navigation. The round-start chat line is stored separately as a plain announcement so it survives the reload.

**Room teardown.** rtc was removing users and deleting rooms on socket disconnect. The LeetCode redirect tears down and reinjects the panel iframe, which drops the socket — so the room, its history, and its round state were being destroyed and recreated seconds later. Rooms now live until central-service sends `room-expired`.

**Identity.** The extension sent `email` as the socket name and userHandle while central-service sent the auth ID, giving `room.Users` two entries per person, only one of which resolved to a live connection. Both now send `userId`, so broadcasts reach everyone and cleanup removes the key it created.

Tested manually with two accounts: room join, round start, and mid-round join all produce the expected chat log and redirect.

